### PR TITLE
Fix exhibitions section id

### DIFF
--- a/utstillinger.html
+++ b/utstillinger.html
@@ -64,7 +64,7 @@
 
   <!-- Main Content Container -->
   <div class="max-w-7xl mx-auto p-4">
-    <section id="ustillinger" class="my-8">
+    <section id="utstillinger" class="my-8">
       <h1 class="text-3xl mb-4 text-[oklch(0.378_0.077_168.94)]">UTSTILLINGER</h1>
       <p class="text-gray-700 mb-6">
         Meråker kunstforening arrangerer minst en årlig felles kunstutstilling hvor alle våre medlemmer kan stille ut


### PR DESCRIPTION
## Summary
- fix the typo in the Utstillinger page so the section id is correct

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68401445057c832a88f55a3fe0148c46