### PR TITLE
Add SEO metadata to site pages

### DIFF
--- a/blimedlem.html
+++ b/blimedlem.html
@@ -5,8 +5,43 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Bli medlem - Meråker Kunstforening</title>
+  <!-- Primary SEO meta tags -->
+  <meta name="description" content="Bli medlem i Meråker Kunstforening og delta i kunsttreff, utstillinger og heimlaga-butikken." />
+  <meta name="keywords" content="medlemskap, Meråker, kunst, kunstforening, heimlaga" />
+  <link rel="canonical" href="https://merakerkunstforening.no/blimedlem.html" />
+  <meta name="robots" content="index, follow" />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://merakerkunstforening.no/blimedlem.html" />
+  <meta property="og:title" content="Bli medlem - Meråker Kunstforening" />
+  <meta property="og:description" content="Bli medlem i Meråker Kunstforening og delta i kunsttreff, utstillinger og heimlaga-butikken." />
+  <meta property="og:image" content="https://merakerkunstforening.no/images/MeraakerLogoBlack.png" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:url" content="https://merakerkunstforening.no/blimedlem.html" />
+  <meta name="twitter:title" content="Bli medlem - Meråker Kunstforening" />
+  <meta name="twitter:description" content="Bli medlem i Meråker Kunstforening og delta i kunsttreff, utstillinger og heimlaga-butikken." />
+  <meta name="twitter:image" content="https://merakerkunstforening.no/images/MeraakerLogoBlack.png" />
+
+  <!-- Structured data for search engines -->
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Meråker Kunstforening",
+      "url": "https://merakerkunstforening.no/",
+      "logo": "https://merakerkunstforening.no/images/MeraakerLogoBlack.png",
+      "sameAs": [
+        "https://www.facebook.com/Mer%C3%A5ker-kunstforening-100064623312280"
+      ]
+    }
+    </script>
   <!-- Tailwind CSS via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Preconnect hint for Facebook domain to speed up iframe requests -->
+  <link rel="preconnect" href="https://www.facebook.com" crossorigin />
 </head>
 
 <body class="bg-white font-sans">

--- a/heimlaga.html
+++ b/heimlaga.html
@@ -1,12 +1,47 @@
 <!DOCTYPE html>
 <html lang="no">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Heimlaga - Meråker Kunstforening</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Heimlaga - Meråker Kunstforening</title>
+  <!-- Primary SEO meta tags -->
+  <meta name="description" content="Heimlaga i Meråker – butikk med håndverk fra våre medlemmer og informasjon for utstillere." />
+  <meta name="keywords" content="Heimlaga, Meråker, håndverk, butikk, utstiller, kunstforening" />
+  <link rel="canonical" href="https://merakerkunstforening.no/heimlaga.html" />
+  <meta name="robots" content="index, follow" />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://merakerkunstforening.no/heimlaga.html" />
+  <meta property="og:title" content="Heimlaga - Meråker Kunstforening" />
+  <meta property="og:description" content="Heimlaga i Meråker – butikk med håndverk fra våre medlemmer og informasjon for utstillere." />
+  <meta property="og:image" content="https://merakerkunstforening.no/images/MeraakerLogoBlack.png" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:url" content="https://merakerkunstforening.no/heimlaga.html" />
+  <meta name="twitter:title" content="Heimlaga - Meråker Kunstforening" />
+  <meta name="twitter:description" content="Heimlaga i Meråker – butikk med håndverk fra våre medlemmer og informasjon for utstillere." />
+  <meta name="twitter:image" content="https://merakerkunstforening.no/images/MeraakerLogoBlack.png" />
+
+  <!-- Structured data for search engines -->
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Meråker Kunstforening",
+      "url": "https://merakerkunstforening.no/",
+      "logo": "https://merakerkunstforening.no/images/MeraakerLogoBlack.png",
+      "sameAs": [
+        "https://www.facebook.com/Mer%C3%A5ker-kunstforening-100064623312280"
+      ]
+    }
+    </script>
     <!-- Tailwind CSS via CDN -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <!-- Lightbox CSS -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Preconnect hint for Facebook domain to speed up iframe requests -->
+  <link rel="preconnect" href="https://www.facebook.com" crossorigin />
+  <!-- Lightbox CSS -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.3/css/lightbox.min.css" rel="stylesheet" />
   </head>
   <body class="bg-white font-sans">

--- a/kontakt.html
+++ b/kontakt.html
@@ -5,8 +5,43 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Kontakt - Meråker Kunstforening</title>
+  <!-- Primary SEO meta tags -->
+  <meta name="description" content="Kontakt Meråker Kunstforening og se oversikt over styremedlemmer." />
+  <meta name="keywords" content="kontakt, styre, Meråker kunstforening" />
+  <link rel="canonical" href="https://merakerkunstforening.no/kontakt.html" />
+  <meta name="robots" content="index, follow" />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://merakerkunstforening.no/kontakt.html" />
+  <meta property="og:title" content="Kontakt - Meråker Kunstforening" />
+  <meta property="og:description" content="Kontakt Meråker Kunstforening og se oversikt over styremedlemmer." />
+  <meta property="og:image" content="https://merakerkunstforening.no/images/MeraakerLogoBlack.png" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:url" content="https://merakerkunstforening.no/kontakt.html" />
+  <meta name="twitter:title" content="Kontakt - Meråker Kunstforening" />
+  <meta name="twitter:description" content="Kontakt Meråker Kunstforening og se oversikt over styremedlemmer." />
+  <meta name="twitter:image" content="https://merakerkunstforening.no/images/MeraakerLogoBlack.png" />
+
+  <!-- Structured data for search engines -->
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Meråker Kunstforening",
+      "url": "https://merakerkunstforening.no/",
+      "logo": "https://merakerkunstforening.no/images/MeraakerLogoBlack.png",
+      "sameAs": [
+        "https://www.facebook.com/Mer%C3%A5ker-kunstforening-100064623312280"
+      ]
+    }
+    </script>
   <!-- Tailwind CSS via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Preconnect hint for Facebook domain to speed up iframe requests -->
+  <link rel="preconnect" href="https://www.facebook.com" crossorigin />
 </head>
 
 <body class="bg-white font-sans">

--- a/medlemmer.html
+++ b/medlemmer.html
@@ -5,8 +5,43 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Medlemmer - Meråker Kunstforening</title>
+  <!-- Primary SEO meta tags -->
+  <meta name="description" content="Oversikt over medlemmer i Meråker Kunstforening." />
+  <meta name="keywords" content="medlemmer, Meråker kunstforening, liste" />
+  <link rel="canonical" href="https://merakerkunstforening.no/medlemmer.html" />
+  <meta name="robots" content="index, follow" />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://merakerkunstforening.no/medlemmer.html" />
+  <meta property="og:title" content="Medlemmer - Meråker Kunstforening" />
+  <meta property="og:description" content="Oversikt over medlemmer i Meråker Kunstforening." />
+  <meta property="og:image" content="https://merakerkunstforening.no/images/MeraakerLogoBlack.png" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:url" content="https://merakerkunstforening.no/medlemmer.html" />
+  <meta name="twitter:title" content="Medlemmer - Meråker Kunstforening" />
+  <meta name="twitter:description" content="Oversikt over medlemmer i Meråker Kunstforening." />
+  <meta name="twitter:image" content="https://merakerkunstforening.no/images/MeraakerLogoBlack.png" />
+
+  <!-- Structured data for search engines -->
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Meråker Kunstforening",
+      "url": "https://merakerkunstforening.no/",
+      "logo": "https://merakerkunstforening.no/images/MeraakerLogoBlack.png",
+      "sameAs": [
+        "https://www.facebook.com/Mer%C3%A5ker-kunstforening-100064623312280"
+      ]
+    }
+    </script>
   <!-- Tailwind CSS via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Preconnect hint for Facebook domain to speed up iframe requests -->
+  <link rel="preconnect" href="https://www.facebook.com" crossorigin />
 </head>
 
 <body class="bg-white font-sans">

--- a/om.html
+++ b/om.html
@@ -5,8 +5,43 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Om oss - Meråker Kunstforening</title>
+  <!-- Primary SEO meta tags -->
+  <meta name="description" content="Historien og målsettingen til Meråker Kunstforening." />
+  <meta name="keywords" content="Meråker, kunst, kunstforening, historie" />
+  <link rel="canonical" href="https://merakerkunstforening.no/om.html" />
+  <meta name="robots" content="index, follow" />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://merakerkunstforening.no/om.html" />
+  <meta property="og:title" content="Om oss - Meråker Kunstforening" />
+  <meta property="og:description" content="Historien og målsettingen til Meråker Kunstforening." />
+  <meta property="og:image" content="https://merakerkunstforening.no/images/MeraakerLogoBlack.png" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:url" content="https://merakerkunstforening.no/om.html" />
+  <meta name="twitter:title" content="Om oss - Meråker Kunstforening" />
+  <meta name="twitter:description" content="Historien og målsettingen til Meråker Kunstforening." />
+  <meta name="twitter:image" content="https://merakerkunstforening.no/images/MeraakerLogoBlack.png" />
+
+  <!-- Structured data for search engines -->
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Meråker Kunstforening",
+      "url": "https://merakerkunstforening.no/",
+      "logo": "https://merakerkunstforening.no/images/MeraakerLogoBlack.png",
+      "sameAs": [
+        "https://www.facebook.com/Mer%C3%A5ker-kunstforening-100064623312280"
+      ]
+    }
+    </script>
   <!-- Tailwind CSS via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Preconnect hint for Facebook domain to speed up iframe requests -->
+  <link rel="preconnect" href="https://www.facebook.com" crossorigin />
 </head>
 
 <body class="bg-white font-sans">

--- a/utstillinger.html
+++ b/utstillinger.html
@@ -5,8 +5,43 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Utstillinger - Meråker Kunstforening</title>
+  <!-- Primary SEO meta tags -->
+  <meta name="description" content="Informasjon om kommende og tidligere utstillinger arrangert av Meråker Kunstforening." />
+  <meta name="keywords" content="utstillinger, Meråker kunstforening, kunstutstilling" />
+  <link rel="canonical" href="https://merakerkunstforening.no/utstillinger.html" />
+  <meta name="robots" content="index, follow" />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://merakerkunstforening.no/utstillinger.html" />
+  <meta property="og:title" content="Utstillinger - Meråker Kunstforening" />
+  <meta property="og:description" content="Informasjon om kommende og tidligere utstillinger arrangert av Meråker Kunstforening." />
+  <meta property="og:image" content="https://merakerkunstforening.no/images/MeraakerLogoBlack.png" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:url" content="https://merakerkunstforening.no/utstillinger.html" />
+  <meta name="twitter:title" content="Utstillinger - Meråker Kunstforening" />
+  <meta name="twitter:description" content="Informasjon om kommende og tidligere utstillinger arrangert av Meråker Kunstforening." />
+  <meta name="twitter:image" content="https://merakerkunstforening.no/images/MeraakerLogoBlack.png" />
+
+  <!-- Structured data for search engines -->
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Meråker Kunstforening",
+      "url": "https://merakerkunstforening.no/",
+      "logo": "https://merakerkunstforening.no/images/MeraakerLogoBlack.png",
+      "sameAs": [
+        "https://www.facebook.com/Mer%C3%A5ker-kunstforening-100064623312280"
+      ]
+    }
+    </script>
   <!-- Tailwind CSS via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Preconnect hint for Facebook domain to speed up iframe requests -->
+  <link rel="preconnect" href="https://www.facebook.com" crossorigin />
 </head>
 
 <body class="bg-white font-sans">


### PR DESCRIPTION
## Summary
- propagate SEO metadata from `index.html` to all site pages
- add Open Graph, Twitter cards, canonical URLs and structured data to improve search visibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684015cd2074832aa5d9b334b6b2187b