### PR TITLE
Fix Facebook icon alignment in navigation

### DIFF
--- a/heimlaga.html
+++ b/heimlaga.html
@@ -82,16 +82,16 @@
                 class="py-5 px-3 text-gray-700 text-lg hover:text-[oklch(0.448_0.119_151.328)]">UTSTILLINGER</a>
               <a href="kontakt.html"
                 class="py-5 px-3 text-gray-700 text-lg hover:text-[oklch(0.448_0.119_151.328)]">KONTAKT</a>
-              <!-- Facebook Icon Link - Desktop -->
-              <a href="https://www.facebook.com/p/Mer%C3%A5ker-kunstforening-100064623312280/"
-                class="py-5 px-3 text-gray-700 hover:text-[oklch(0.378_0.077_168.94)]" target="_blank"
-                rel="noopener noreferrer">
-                <svg class="w-6 h-6 fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                  <path
-                    d="M12 2C6.477 2 2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.879V14.89h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.989C18.343 21.129 22 16.99 22 12c0-5.523-4.477-10-10-10z" />
-                </svg>
-              </a>
             </div>
+            <!-- Facebook Icon Link - Desktop -->
+            <a href="https://www.facebook.com/p/Mer%C3%A5ker-kunstforening-100064623312280/"
+              class="py-5 px-3 text-gray-700 hover:text-[oklch(0.378_0.077_168.94)]" target="_blank"
+              rel="noopener noreferrer">
+              <svg class="w-6 h-6 fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path
+                  d="M12 2C6.477 2 2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.879V14.89h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.989C18.343 21.129 22 16.99 22 12c0-5.523-4.477-10-10-10z" />
+              </svg>
+            </a>
           </div>
           <!-- Bottom Divider Line -->
           <hr class="border-t border-[oklch(0.378_0.077_168.94)] opacity-30" />

--- a/kontakt.html
+++ b/kontakt.html
@@ -79,16 +79,16 @@
                 class="py-5 px-3 text-gray-700 text-lg hover:text-[oklch(0.448_0.119_151.328)]">UTSTILLINGER</a>
               <a href="kontakt.html"
                 class="py-5 px-3 text-gray-700 text-lg font-bold hover:text-[oklch(0.448_0.119_151.328)]">KONTAKT</a>
-              <!-- Facebook Icon Link - Desktop -->
-              <a href="https://www.facebook.com/p/Mer%C3%A5ker-kunstforening-100064623312280/"
-                class="py-5 px-3 text-gray-700 hover:text-[oklch(0.378_0.077_168.94)]" target="_blank"
-                rel="noopener noreferrer">
-                <svg class="w-6 h-6 fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                  <path
-                    d="M12 2C6.477 2 2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.879V14.89h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.989C18.343 21.129 22 16.99 22 12c0-5.523-4.477-10-10-10z" />
-                </svg>
-              </a>
             </div>
+            <!-- Facebook Icon Link - Desktop -->
+            <a href="https://www.facebook.com/p/Mer%C3%A5ker-kunstforening-100064623312280/"
+              class="py-5 px-3 text-gray-700 hover:text-[oklch(0.378_0.077_168.94)]" target="_blank"
+              rel="noopener noreferrer">
+              <svg class="w-6 h-6 fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path
+                  d="M12 2C6.477 2 2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.879V14.89h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.989C18.343 21.129 22 16.99 22 12c0-5.523-4.477-10-10-10z" />
+              </svg>
+            </a>
           </div>
           <hr class="border-t border-[oklch(0.378_0.077_168.94)] opacity-30">
         </div>

--- a/utstillinger.html
+++ b/utstillinger.html
@@ -82,16 +82,16 @@
                 class="py-5 px-3 text-gray-700 text-lg font-bold hover:text-[oklch(0.448_0.119_151.328)]">UTSTILLINGER</a>
               <a href="kontakt.html"
                 class="py-5 px-3 text-gray-700 text-lg hover:text-[oklch(0.448_0.119_151.328)]">KONTAKT</a>
-              <!-- Facebook Icon Link - Desktop -->
-              <a href="https://www.facebook.com/p/Mer%C3%A5ker-kunstforening-100064623312280/"
-                class="py-5 px-3 text-gray-700 hover:text-[oklch(0.378_0.077_168.94)]" target="_blank"
-                rel="noopener noreferrer">
-                <svg class="w-6 h-6 fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                  <path
-                    d="M12 2C6.477 2 2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.879V14.89h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.989C18.343 21.129 22 16.99 22 12c0-5.523-4.477-10-10-10z" />
-                </svg>
-              </a>
             </div>
+            <!-- Facebook Icon Link - Desktop -->
+            <a href="https://www.facebook.com/p/Mer%C3%A5ker-kunstforening-100064623312280/"
+              class="py-5 px-3 text-gray-700 hover:text-[oklch(0.378_0.077_168.94)]" target="_blank"
+              rel="noopener noreferrer">
+              <svg class="w-6 h-6 fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path
+                  d="M12 2C6.477 2 2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.879V14.89h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.989C18.343 21.129 22 16.99 22 12c0-5.523-4.477-10-10-10z" />
+              </svg>
+            </a>
           </div>
           <hr class="border-t border-[oklch(0.378_0.077_168.94)] opacity-30">
         </div>


### PR DESCRIPTION
## Summary
- place the desktop Facebook icon outside the nav links container for all pages
- adjust navigation markup on *heimlaga*, *utstillinger*, and *kontakt* pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840705fbc58832a89dce52d4985fa3b